### PR TITLE
Update Debian version to Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="1.17.3-erlang-27.1-debian-bullseye-20240926"
+ARG VARIANT="1.17.3-erlang-27.1.3-debian-bookworm-20250811"
 FROM hexpm/elixir:${VARIANT}
 
 # ARGs declared before FROM are not persisted beyond the FROM instruction.


### PR DESCRIPTION
The current Debian version (Bullseye) is not suitable for some deps in https://github.com/blockscout/blockscout (e.g. they throw errors about obsolete `libc` version when compiling). With `Bookworm` the compilation works fine.